### PR TITLE
using SPIRITLM_CHECKPOINTS_DIR for custom checkpoints dir

### DIFF
--- a/checkpoints/README.md
+++ b/checkpoints/README.md
@@ -50,3 +50,4 @@ checkpoints/
         ├── tokenizer_config.json
         └── tokenizer.model
 ```
+You can export `SPIRITLM_CHECKPOINTS_DIR` to point to a differnt directory where you downloaded checkpoints.

--- a/spiritlm/model/spiritlm_model.py
+++ b/spiritlm/model/spiritlm_model.py
@@ -29,8 +29,11 @@ from transformers import GenerationConfig, LlamaForCausalLM, LlamaTokenizer, set
 _logger = logging.getLogger(__name__)
 
 
-CHECKPOINT_DIR = Path(__file__).parent.parent.parent / "checkpoints/spiritlm_model"
+# Get the base checkpoints directory from environment variable or use the default base path
+base_checkpoints_dir = Path(os.getenv("SPIRITLM_CHECKPOINTS_DIR", Path(__file__).parent.parent.parent / "checkpoints"))
 
+# Append 'spiritlm_model' to the base path
+CHECKPOINT_DIR = base_checkpoints_dir / "spiritlm_model"
 
 class ContentType(Enum):
     TEXT = "TEXT"

--- a/spiritlm/speech_tokenizer/f0/__init__.py
+++ b/spiritlm/speech_tokenizer/f0/__init__.py
@@ -5,12 +5,17 @@
 # found in the LICENSE file in the root directory of this source tree.
 
 from pathlib import Path
+import os
 
 import torch
 
 from .f0_tokenizer import F0Tokenizer
 
-CHECKPOINT_DIR = Path(__file__).parents[3] / "checkpoints/speech_tokenizer"
+# Get the base checkpoints directory from environment variable or use the default base path
+base_checkpoints_dir = Path(os.getenv("SPIRITLM_CHECKPOINTS_DIR", Path(__file__).parents[3] / "checkpoints"))
+
+# Append 'speech_tokenizer' to the base path
+CHECKPOINT_DIR = base_checkpoints_dir / "speech_tokenizer"
 
 CURRENT_DEVICE = (
     torch.device(torch.cuda.current_device())

--- a/spiritlm/speech_tokenizer/hifigan/__init__.py
+++ b/spiritlm/speech_tokenizer/hifigan/__init__.py
@@ -5,12 +5,17 @@
 # found in the LICENSE file in the root directory of this source tree.
 
 from pathlib import Path
+import os
 
 import torch
 
 from .hifigan_vocoder import HifiGANVocoder
 
-CHECKPOINT_DIR = Path(__file__).parents[3] / "checkpoints/speech_tokenizer"
+# Get the base checkpoints directory from environment variable or use the default base path
+base_checkpoints_dir = Path(os.getenv("SPIRITLM_CHECKPOINTS_DIR", Path(__file__).parents[3] / "checkpoints"))
+
+# Append 'speech_tokenizer' to the base path
+CHECKPOINT_DIR = base_checkpoints_dir / "speech_tokenizer"
 
 CURRENT_DEVICE = (
     torch.device(torch.cuda.current_device())

--- a/spiritlm/speech_tokenizer/hubert/__init__.py
+++ b/spiritlm/speech_tokenizer/hubert/__init__.py
@@ -5,12 +5,17 @@
 # found in the LICENSE file in the root directory of this source tree.
 
 from pathlib import Path
+import os
 
 import torch
 
 from .hubert_tokenizer import HubertTokenizer
 
-CHECKPOINT_DIR = Path(__file__).parents[3] / "checkpoints/speech_tokenizer"
+# Get the base checkpoints directory from environment variable or use the default base path
+base_checkpoints_dir = Path(os.getenv("SPIRITLM_CHECKPOINTS_DIR", Path(__file__).parents[3] / "checkpoints"))
+
+# Append 'speech_tokenizer' to the base path
+CHECKPOINT_DIR = base_checkpoints_dir / "speech_tokenizer"
 
 CURRENT_DEVICE = (
     torch.device(torch.cuda.current_device())

--- a/spiritlm/speech_tokenizer/style_encoder/__init__.py
+++ b/spiritlm/speech_tokenizer/style_encoder/__init__.py
@@ -6,6 +6,7 @@
 
 
 import logging
+import os
 from pathlib import Path
 
 import torch
@@ -14,7 +15,11 @@ from .w2v2_encoder import Wav2Vec2StyleEncoder
 
 _logger = logging.getLogger(__name__)
 
-CHECKPOINT_DIR = Path(__file__).parents[3] / "checkpoints/speech_tokenizer"
+# Get the base checkpoints directory from environment variable or use the default base path
+base_checkpoints_dir = Path(os.getenv("SPIRITLM_CHECKPOINTS_DIR", Path(__file__).parents[3] / "checkpoints"))
+
+# Append 'speech_tokenizer' to the base path
+CHECKPOINT_DIR = base_checkpoints_dir / "speech_tokenizer"
 
 CURRENT_DEVICE = (
     torch.device(torch.cuda.current_device())


### PR DESCRIPTION
After downloading checkpoints, usually these resides on a different directory outside the repo, so adding support for an environment variable `SPIRITLM_CHECKPOINTS_DIR` where it points to a custom location for downloaded checkpoints. While maintaining backward compatibility in case the environment variable is not defined

This should resolves #11 